### PR TITLE
[flexibleDateInput] Remove unused CSS reference

### DIFF
--- a/plugins/flexibleDateInput/flexibleDateInput.yml
+++ b/plugins/flexibleDateInput/flexibleDateInput.yml
@@ -4,7 +4,5 @@ version: 1.0
 ui:
     javascript:
         - flexibleDateInput.js
-    css:
-        - flexibleDateInput.css
     assets:
         /: .


### PR DESCRIPTION
Removed unused CSS file reference from flexibleDateInput.yml

Returns error
```
error serving file plugins\qxxxgit\flexibleDateInput\flexibleDateInput.css: open plugins\qxxxgit\flexibleDateInput\flexibleDateInput.css: The system cannot find the file specified.
```